### PR TITLE
Fix vercel deployment error for server entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts --platform=node --bundle --format=esm --outdir=dist --external:express --external:express-session --external:passport --external:passport-local --external:bcrypt --external:ws --external:memorystore --external:connect-pg-simple --external:drizzle-orm --external:openid-client --external:zod --external:zod-validation-error --external:date-fns --external:jspdf --external:html2canvas --external:purify-js",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"


### PR DESCRIPTION
Corrected the `esbuild` command in the `package.json` build script to resolve a Vercel deployment error.

The previous `esbuild` command used `--packages=external`, which caused an error because it conflicted with the entry point `server/index.ts`. This change replaces the incorrect flag with explicit `--external:` flags for each dependency that should not be bundled, allowing the server build to complete successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f8a74e1-61d4-4a13-a7a6-67e992a9fc49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f8a74e1-61d4-4a13-a7a6-67e992a9fc49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

